### PR TITLE
Fix bugs in document_create.html template

### DIFF
--- a/pinax/templates/templates/pinax/documents/document_create.html
+++ b/pinax/templates/templates/pinax/documents/document_create.html
@@ -17,7 +17,7 @@
     <form method="POST" action="{% url 'pinax_documents:document_create' %}" enctype="multipart/form-data">
         {% csrf_token %}
         <label class="custom-file">
-            <input type="file" id="id_file" class="custom-file-input">
+            <input type="file" id="id_file" name="file" class="custom-file-input">
             <span class="custom-file-control" data-file="Choose file..."></span>
         </label>
         <div class="form-actions">

--- a/pinax/templates/templates/pinax/documents/document_create.html
+++ b/pinax/templates/templates/pinax/documents/document_create.html
@@ -16,6 +16,10 @@
 
     <form method="POST" action="{% url 'pinax_documents:document_create' %}" enctype="multipart/form-data">
         {% csrf_token %}
+        {% for hidden_field in form.hidden_fields %}
+            {{ hidden_field.errors }}
+            {{ hidden_field }}
+        {% endfor %}
         <label class="custom-file">
             <input type="file" id="id_file" name="file" class="custom-file-input">
             <span class="custom-file-control" data-file="Choose file..."></span>


### PR DESCRIPTION
Added File input needed the "file" field binding in order to work, and added hidden "folder" in the form to have the file assigned to the appropriate folder.