### PR TITLE
Move over pinax-points templates

### DIFF
--- a/pinax/templates/templates/pinax/admin/pinax/points/awardedpointvalue/change_list.html
+++ b/pinax/templates/templates/pinax/admin/pinax/points/awardedpointvalue/change_list.html
@@ -1,0 +1,18 @@
+{% extends "admin/change_list.html" %}
+
+{% load i18n %}
+
+{% block object-tools %}
+    {% if has_add_permission %}
+        <ul class="object-tools">
+            <li>
+                <a href="one_off_points/">Award one-points</a>
+            </li>
+            <li>
+                <a href="add/{% if is_popup %}?_popup=1{% endif %}" class="addlink">
+                    {% blocktrans with cl.opts.verbose_name as name %}Add {{ name }}{% endblocktrans %}
+                </a>
+            </li>
+        </ul>
+    {% endif %}
+{% endblock %}

--- a/pinax/templates/templates/pinax/admin/pinax/points/awardedpointvalue/change_list.html
+++ b/pinax/templates/templates/pinax/admin/pinax/points/awardedpointvalue/change_list.html
@@ -6,7 +6,7 @@
     {% if has_add_permission %}
         <ul class="object-tools">
             <li>
-                <a href="one_off_points/">Award one-points</a>
+                <a href="one_off_points/">{% trans "Award one-off points" %}</a>
             </li>
             <li>
                 <a href="add/{% if is_popup %}?_popup=1{% endif %}" class="addlink">

--- a/pinax/templates/templates/pinax/points/one_off_points.html
+++ b/pinax/templates/templates/pinax/points/one_off_points.html
@@ -1,0 +1,34 @@
+{% extends "admin/base_site.html" %}
+
+{% load i18n admin_modify adminmedia %}
+
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% admin_media_prefix %}css/forms.css" />{% endblock %}
+
+{% block breadcrumbs %}
+    <div class="breadcrumbs">
+        <a href="../../">{% trans "Home" %}</a>
+        &rsaquo;
+        <a href="../">{{ opts.app_label|capfirst }}</a>
+        &rsaquo;
+        <a href="../">{{ opts.verbose_name_plural|capfirst }}</a>
+        &rsaquo;
+        Award one-off points
+    </div>
+{% endblock %}
+
+{% block content %}
+<div id="content-main">
+    <h1>Issue one-off point rewards</h1>
+    
+    <form method="POST" action="">
+        {% csrf_token %}
+        {% for fieldset in form %}
+            {% include "admin/includes/fieldset.html" %}
+        {% endfor %}
+        
+        <div class="submit-row">
+            <input type="submit" value="Award" class="default" />
+        </div>
+    </form>
+</div>
+{% endblock %}

--- a/pinax/templates/templates/pinax/points/one_off_points.html
+++ b/pinax/templates/templates/pinax/points/one_off_points.html
@@ -12,13 +12,13 @@
         &rsaquo;
         <a href="../">{{ opts.verbose_name_plural|capfirst }}</a>
         &rsaquo;
-        Award one-off points
+        {% trans "Award one-off points" %}
     </div>
 {% endblock %}
 
 {% block content %}
 <div id="content-main">
-    <h1>Issue one-off point rewards</h1>
+    <h1>{% trans "Issue one-off point rewards" %}</h1>
     
     <form method="POST" action="">
         {% csrf_token %}
@@ -27,7 +27,8 @@
         {% endfor %}
         
         <div class="submit-row">
-            <input type="submit" value="Award" class="default" />
+            {% trans "Award" as submit_text %}
+            <input type="submit" value="{{ submit_text }}" class="default" />
         </div>
     </form>
 </div>


### PR DESCRIPTION
Moves the templates from pinax-points to this project to prepare for pinax-points v1.0.0 release. 

These templates are a little different than templates from most other pinax apps as they are admin-specific, and seem to be tightly coupled with the `one_off_points` admin functionality from pinax-points.

Fixes pinax/pinax-points#15.