### PR TITLE
Remove old Django versions from matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,11 +16,12 @@ common: &common
     - run:
         name: upload coverage report
         command: |
-          if [[ "$TOXENV" != checkqa ]]; then
-              PATH=$HOME/.local/bin:$PATH
-              pip install --user codecov
-              ~/.local/bin/codecov --required --flags $CIRCLE_JOB
-          fi
+           if [[ "$UPLOAD_COVERAGE" != 0 ]]; then
+               PATH=$HOME/.local/bin:$PATH
+               pip install --user codecov
+               coverage xml
+               ~/.local/bin/codecov --required -X search gcov pycov -f coverage.xml --flags $CIRCLE_JOB
+           fi
     - save_cache:
         paths:
           - .tox
@@ -35,37 +36,14 @@ jobs:
     docker:
       - image: circleci/python:3.6
         environment:
-          TOXENV=checkqa
-  py27dj18:
-    <<: *common
-    docker:
-      - image: circleci/python:2.7
-        environment:
-          TOXENV=py27-dj18
-  py27dj110:
-    <<: *common
-    docker:
-      - image: circleci/python:2.7
-        environment:
-          TOXENV=py27-dj110
+          - TOXENV=checkqa
+          - UPLOAD_COVERAGE=0
   py27dj111:
     <<: *common
     docker:
       - image: circleci/python:2.7
         environment:
           TOXENV=py27-dj111
-  py34dj18:
-    <<: *common
-    docker:
-      - image: circleci/python:3.4
-        environment:
-          TOXENV=py34-dj18
-  py34dj110:
-    <<: *common
-    docker:
-      - image: circleci/python:3.4
-        environment:
-          TOXENV=py34-dj110
   py34dj111:
     <<: *common
     docker:
@@ -78,18 +56,6 @@ jobs:
       - image: circleci/python:3.4
         environment:
           TOXENV=py34-dj20
-  py35dj18:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-        environment:
-          TOXENV=py35-dj18
-  py35dj110:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-        environment:
-          TOXENV=py35-dj110
   py35dj111:
     <<: *common
     docker:
@@ -120,15 +86,9 @@ workflows:
   test:
     jobs:
       - lint
-      - py27dj18
-      - py27dj110
       - py27dj111
-      - py34dj18
-      - py34dj110
       - py34dj111
       - py34dj20
-      - py35dj18
-      - py35dj110
       - py35dj111
       - py35dj20
       - py36dj111


### PR DESCRIPTION
We're saying goodbye to old Django versions, and older apps use pinax-theme-bootstrap or similar.