### PR TITLE
Update README to include addition of bootstrapform to INSTALLED_APPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,12 @@ To install pinax-templates:
 $ pip install pinax-templates
 ```
 
-Add `pinax.templates` to your `INSTALLED_APPS` setting:
+Add `bootstrapform` and `pinax.templates` to your `INSTALLED_APPS` setting:
 
 ```python
 INSTALLED_APPS = [
     # other apps
+    "bootstrapform",
     "pinax.templates",
 ]
 ```


### PR DESCRIPTION
This PR updates the README and will help new users get started.

`pinax-templates` uses template tags provided by app `django-bootstrap-form`. If the latter app is not in `INSTALLED_APPS` then `pinax-templates` errors out: _'bootstrap' is not a registered tag library_

